### PR TITLE
[v1.1.1] Cast Redis::exists result to boolean

### DIFF
--- a/src/Traits/Nonceable.php
+++ b/src/Traits/Nonceable.php
@@ -83,7 +83,7 @@ trait Nonceable
     {
         list($formattedTitle, $_) = $this->getNonceByTitle($title);
 
-        return Redis::exists($this->formCacheKey($formattedTitle, $nonce));
+        return (bool)Redis::exists($this->formCacheKey($formattedTitle, $nonce));
     }
 
     public function isNonceSense(string $title, string $nonce): bool


### PR DESCRIPTION
It was returning 1 and apprently Laravel doesn't like that when the method return type is restricted to boolean 