### PR TITLE
[v1.1.1] Dynamic noncing unique ID and casting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Below is the table of key methods provided by the `LivewireNonceable` package al
 
 You can check out the package's [changelogs](https://app.whatthediff.ai/changelog/github/VPremiss/Livewire-Nonceable) online via WTD.
 
+### Progress
+
+You can also checkout the project's [roadmap](https://github.com/orgs/VPremiss/projects/8) among others in the organization's dedicated section for [projects](https://github.com/orgs/VPremiss/projects).
+
 
 ## Support
 

--- a/src/Traits/Nonceable.php
+++ b/src/Traits/Nonceable.php
@@ -14,7 +14,6 @@ trait Nonceable
     use HasNoncingValidations;
 
     public array $nonces;
-    public string $nonceUniqueId;
 
     public function mountNonceable()
     {
@@ -28,7 +27,6 @@ trait Nonceable
         }
 
         $this->nonces = $nonces;
-        $this->nonceUniqueId = $this->formatCacheKey($this->getNonceUniqueId());
     }
 
     private function formatCacheKey(string $key): string
@@ -52,7 +50,11 @@ trait Nonceable
 
     private function formCacheKey(string $formattedTitle, string $nonce): string
     {
-        return "nonce:$formattedTitle:{$this->nonceUniqueId}:$nonce";
+        $this->validateTheNonceUniqueId();
+
+        $uniqueId = $this->formatCacheKey($this->getNonceUniqueId());
+
+        return "nonce:$formattedTitle:{$uniqueId}:$nonce";
     }
 
     protected function generateNonce(string $title): string

--- a/src/Traits/Nonceable.php
+++ b/src/Traits/Nonceable.php
@@ -83,7 +83,7 @@ trait Nonceable
     {
         list($formattedTitle, $_) = $this->getNonceByTitle($title);
 
-        return Redis::exists($this->formCacheKey($formattedTitle, $nonce));
+        return (bool)Redis::exists($this->formCacheKey($formattedTitle, $nonce));
     }
 
     public function isNonceSense(string $title, string $nonce): bool


### PR DESCRIPTION
1. [[v1.1.0] Dynamic noncing unique ID](https://github.com/VPremiss/Livewire-Nonceable/commit/e70dff791a80c55f9a60232546d958dcda90d40e)
2. [[v1.1.1] Fix: Cast return as boolean](https://github.com/VPremiss/Livewire-Nonceable/commit/bf5f429857ef58492feded5cdf24af4258f035af)